### PR TITLE
Add optional dependancy instruction for linux build

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,9 @@ Build On linux (tested on ubuntu 14.04)
 # installing dependancies
 sudo apt-get install g++ git make libboost1.54-all-dev libssl-dev cmake
 
+# optional dependency
+sudo apt-get install libwebsocketpp-dev
+
 # getting the sources
 git clone https://github.com/gigagg/GiGaSdk.git
 cd GiGaSdk


### PR DESCRIPTION
In my case (raspberry pi 3) the compilation of websocket failed during the build of Casablanca.
Delete CMakeCache and install websocket from apt solved this problem.
